### PR TITLE
Add ability to disable automatic placeholders

### DIFF
--- a/src/NpmWeb/FormBuilder/FormBuilder.php
+++ b/src/NpmWeb/FormBuilder/FormBuilder.php
@@ -382,7 +382,9 @@ class FormBuilder
             : [];
 
         if (!array_key_exists('id', $config->extras) ) $config->extras['id'] = e( $name );
-        if (!array_key_exists('placeholder',$config->extras) ) $config->extras['placeholder'] = $config->label; // configurable?
+        if ($this->auto_placeholders && !array_key_exists('placeholder',$config->extras) ) {
+            $config->extras['placeholder'] = $config->label;
+        }
 
 
         $config->errors = array_key_exists('errors',$options)

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -6,4 +6,5 @@ return array(
     // default col_width for bootstrap:
     // 'col_width' => 'col-md-6',
     'row_per_field' => false,
+    'auto_placeholders' => true,
 );


### PR DESCRIPTION
All of the built-in renderers include a field label, so to also automatically include a placeholder on the field is a bit of duplication. This commit adds a config option to allow disabling the automatic placeholders. They're enabled by default for backward compatibility. When automatic placeholders are disabled, individual placeholders can still be added to fields.
